### PR TITLE
Clarify SignatureConflictError docstring

### DIFF
--- a/src/signia/_core.py
+++ b/src/signia/_core.py
@@ -18,7 +18,7 @@ __all__ = [
 
 
 class SignatureConflictError(ValueError):
-    """Raised when incompatible signatures are merged."""
+    """Raised when merging callables hits conflicting signature metadata."""
 
 
 def mirror_signature(target: Callable[..., Any], source: Callable[..., Any]) -> Callable[..., Any]:


### PR DESCRIPTION
## Summary
- clarify the `SignatureConflictError` docstring to explain when it is raised

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d37b2ad2d883288d2e9d3e24b7e343