### PR TITLE
Enhance merge_signatures conflict handling

### DIFF
--- a/src/signia/_core.py
+++ b/src/signia/_core.py
@@ -17,6 +17,19 @@ __all__ = [
 ]
 
 
+_PARAMETER_KIND_ORDER = (
+    Parameter.POSITIONAL_ONLY,
+    Parameter.POSITIONAL_OR_KEYWORD,
+    Parameter.VAR_POSITIONAL,
+    Parameter.KEYWORD_ONLY,
+    Parameter.VAR_KEYWORD,
+)
+
+
+ConflictDetail = tuple[str, Any, Any]
+ConflictResolver = Callable[[str, Parameter, Parameter, tuple[ConflictDetail, ...]], Parameter]
+
+
 class SignatureConflictError(ValueError):
     """Raised when merging callables hits conflicting signature metadata."""
 
@@ -163,29 +176,117 @@ def _compatible_signatures(left: Signature, right: Signature) -> bool:
     return left.return_annotation == right.return_annotation
 
 
-def merge_signatures(*callables: Callable[..., Any]) -> Signature:
-    """Merge multiple callables into a single :class:`inspect.Signature`."""
+def merge_signatures(
+    *callables: Callable[..., Any] | Signature,
+    policy: str = "prefer-first",
+    on_conflict: str | ConflictResolver | None = None,
+    compare_defaults: bool = True,
+    compare_annotations: bool = True,
+) -> Signature:
+    """Merge callables into a single :class:`inspect.Signature`.
+
+    Parameters
+    ----------
+    *callables:
+        Callables or :class:`inspect.Signature` instances to merge.  Parameters
+        are grouped by kind (positional-only, positional-or-keyword, variadic
+        positional, keyword-only, variadic keyword) to produce a valid merged
+        ordering.
+    policy:
+        Controls which side supplies metadata when no conflict is detected.
+        ``"prefer-first"`` (default) keeps the earliest-seen parameter while
+        borrowing defaults or annotations from later definitions.  ``"prefer-last"``
+        does the opposite.
+    on_conflict:
+        Strategy invoked when parameters disagree according to the comparison
+        rules.  ``None``/``"raise"`` raises :class:`SignatureConflictError`.
+        ``"prefer-annotated"`` keeps whichever candidate includes an annotation,
+        ``"prefer-defaulted"`` keeps whichever declares a default, and a callable
+        may be supplied for custom resolution.  Resolver callables receive
+        ``(name, existing, incoming, conflicts)`` where ``conflicts`` is a tuple of
+        ``(kind, existing_value, incoming_value)`` triples, and must return an
+        :class:`inspect.Parameter`.
+    compare_defaults / compare_annotations:
+        When ``True`` (default) differing defaults or annotations count as
+        conflicts.  Disable these flags to allow the current ``policy`` to decide
+        which value to keep instead.
+
+    Notes
+    -----
+    * Return annotations are always taken from the right-most callable that
+      provides a non-empty annotation.
+    * Conflicts include the mismatching metadata in their error messages and can
+      be resolved with the built-in strategies or a custom resolver.  For example::
+
+          >>> def left(x: int, y: int = 1):
+          ...     ...
+          >>> def right(x: int, y: int = 2):
+          ...     ...
+          >>> merge_signatures(left, right)
+          Traceback (most recent call last):
+          ...
+          SignatureConflictError: Parameter 'y' conflict: default 1 vs 2
+
+          >>> merge_signatures(left, right, compare_defaults=False)
+          <Signature (x: int, y: int = 1)>
+
+          >>> merge_signatures(left, right, on_conflict="prefer-defaulted", policy="prefer-last")
+          <Signature (x: int, y: int = 2)>
+
+    Returns
+    -------
+    :class:`inspect.Signature`
+        Signature comprising the merged parameters and return annotation.
+    """
 
     if not callables:
         raise ValueError("merge_signatures requires at least one callable")
 
-    merged_parameters: OrderedDict[str, Parameter] = OrderedDict()
+    normalised_policy = _normalise_policy(policy)
+    resolver = _normalise_resolver(on_conflict)
+
+    buckets = _initial_parameter_buckets()
+    name_to_parameter: dict[str, Parameter] = {}
+    name_to_kind: dict[str, Any] = {}
+
     return_annotation = Signature.empty
 
-    for function in callables:
-        signature = inspect.signature(function)
+    for target in callables:
+        signature = _ensure_signature(target)
 
         for parameter in signature.parameters.values():
-            existing = merged_parameters.get(parameter.name)
+            existing = name_to_parameter.get(parameter.name)
             if existing is None:
-                merged_parameters[parameter.name] = parameter
+                _add_parameter_to_buckets(buckets, parameter)
+                name_to_parameter[parameter.name] = parameter
+                name_to_kind[parameter.name] = parameter.kind
                 continue
 
-            merged_parameters[parameter.name] = _merge_parameter(existing, parameter)
+            merged = _merge_parameter_metadata(
+                parameter.name,
+                existing,
+                parameter,
+                normalised_policy,
+                resolver,
+                compare_defaults,
+                compare_annotations,
+            )
 
-        return_annotation = _merge_return_annotation(return_annotation, signature.return_annotation)
+            previous_kind = name_to_kind[parameter.name]
+            if previous_kind is merged.kind:
+                buckets[previous_kind][parameter.name] = merged
+            else:
+                del buckets[previous_kind][parameter.name]
+                buckets[merged.kind][parameter.name] = merged
+                name_to_kind[parameter.name] = merged.kind
 
-    return Signature(parameters=list(merged_parameters.values()), return_annotation=return_annotation)
+            name_to_parameter[parameter.name] = merged
+
+        if signature.return_annotation is not Signature.empty:
+            return_annotation = signature.return_annotation
+
+    merged_parameters = list(_iter_bucketed_parameters(buckets))
+    return Signature(parameters=merged_parameters, return_annotation=return_annotation)
 
 
 def combine(
@@ -245,32 +346,255 @@ def _strip_parameter_annotations(signature: Signature) -> Signature:
     return signature.replace(parameters=parameters)
 
 
-def _merge_parameter(existing: Parameter, new: Parameter) -> Parameter:
-    """Merge parameter metadata, preferring previously established values."""
+def _initial_parameter_buckets() -> dict[Any, OrderedDict[str, Parameter]]:
+    """Return empty parameter buckets keyed by :class:`inspect._ParameterKind`."""
 
-    if existing.kind is not new.kind:
-        raise SignatureConflictError(f"Parameter '{existing.name}' kind conflict: {existing.kind} vs {new.kind}")
-
-    default = existing.default
-    if default is Parameter.empty:
-        default = new.default
-    elif new.default is not Parameter.empty and new.default != default:
-        raise SignatureConflictError(f"Parameter '{existing.name}' default conflict")
-
-    annotation = existing.annotation
-    if annotation is Parameter.empty:
-        annotation = new.annotation
-    elif new.annotation is not Parameter.empty and new.annotation != annotation:
-        raise SignatureConflictError(f"Parameter '{existing.name}' annotation conflict")
-
-    return existing.replace(default=default, annotation=annotation)
+    return {kind: OrderedDict() for kind in _PARAMETER_KIND_ORDER}
 
 
-def _merge_return_annotation(current: Any, new: Any) -> Any:
-    """Merge return annotations, preferring previously established values."""
+def _add_parameter_to_buckets(
+    buckets: dict[Any, OrderedDict[str, Parameter]], parameter: Parameter
+) -> None:
+    """Add *parameter* to the bucket matching its kind."""
 
-    if current is Signature.empty:
-        return new
-    if new is Signature.empty or new == current:
-        return current
-    raise SignatureConflictError("Return annotation conflict")
+    buckets[parameter.kind][parameter.name] = parameter
+
+
+def _iter_bucketed_parameters(
+    buckets: dict[Any, OrderedDict[str, Parameter]]
+):
+    """Yield parameters from *buckets* in canonical kind order."""
+
+    for kind in _PARAMETER_KIND_ORDER:
+        yield from buckets[kind].values()
+
+
+def _normalise_policy(policy: str) -> str:
+    """Validate and normalise the merge *policy* argument."""
+
+    allowed = {"prefer-first", "prefer-last"}
+    if policy not in allowed:
+        choices = ", ".join(sorted(allowed))
+        raise ValueError(f"Unsupported policy '{policy}'. Choose one of: {choices}.")
+    return policy
+
+
+def _normalise_resolver(
+    on_conflict: str | ConflictResolver | None,
+):
+    """Validate and normalise the *on_conflict* argument."""
+
+    if on_conflict is None:
+        return None
+    if callable(on_conflict):
+        return on_conflict
+    allowed = {"raise", "prefer-annotated", "prefer-defaulted"}
+    if on_conflict not in allowed:
+        choices = ", ".join(sorted(allowed))
+        raise ValueError(
+            f"Unsupported on_conflict strategy '{on_conflict}'. Choose one of: {choices}."
+        )
+    return on_conflict
+
+
+def _merge_parameter_metadata(
+    name: str,
+    existing: Parameter,
+    incoming: Parameter,
+    policy: str,
+    resolver: str | ConflictResolver | None,
+    compare_defaults: bool,
+    compare_annotations: bool,
+) -> Parameter:
+    """Merge metadata for a parameter encountered multiple times."""
+
+    primary, secondary = _apply_policy(existing, incoming, policy)
+    conflicts = _detect_parameter_conflicts(primary, secondary, compare_defaults, compare_annotations)
+
+    if conflicts:
+        resolved, source = _resolve_parameter_conflict(
+            name,
+            existing,
+            incoming,
+            conflicts,
+            policy,
+            resolver,
+        )
+        if resolved is None:
+            _raise_parameter_conflict(name, conflicts)
+        if resolved.name != name:
+            raise SignatureConflictError(
+                f"Conflict resolver must keep parameter name '{name}', got '{resolved.name}'."
+            )
+
+        counterpart: Parameter | None
+        if source == "existing":
+            counterpart = incoming
+        elif source == "incoming":
+            counterpart = existing
+        else:
+            counterpart = None
+
+        if counterpart is not None:
+            resolved = _finalise_resolved_parameter(resolved, counterpart, conflicts)
+        return resolved
+
+    default = primary.default
+    if default is Parameter.empty and secondary.default is not Parameter.empty:
+        default = secondary.default
+
+    annotation = primary.annotation
+    if annotation is Parameter.empty and secondary.annotation is not Parameter.empty:
+        annotation = secondary.annotation
+
+    return primary.replace(default=default, annotation=annotation)
+
+
+def _apply_policy(existing: Parameter, incoming: Parameter, policy: str) -> tuple[Parameter, Parameter]:
+    """Return the (primary, secondary) parameters according to *policy*."""
+
+    if policy == "prefer-last":
+        return incoming, existing
+    return existing, incoming
+
+
+def _detect_parameter_conflicts(
+    primary: Parameter,
+    secondary: Parameter,
+    compare_defaults: bool,
+    compare_annotations: bool,
+) -> list[ConflictDetail]:
+    """Return a list of conflict descriptors between two parameters."""
+
+    conflicts: list[ConflictDetail] = []
+
+    if primary.kind is not secondary.kind:
+        conflicts.append(("kind", primary.kind, secondary.kind))
+
+    if (
+        compare_defaults
+        and primary.default is not Parameter.empty
+        and secondary.default is not Parameter.empty
+        and primary.default != secondary.default
+    ):
+        conflicts.append(("default", primary.default, secondary.default))
+
+    if (
+        compare_annotations
+        and primary.annotation is not Parameter.empty
+        and secondary.annotation is not Parameter.empty
+        and primary.annotation != secondary.annotation
+    ):
+        conflicts.append(("annotation", primary.annotation, secondary.annotation))
+
+    return conflicts
+
+
+def _resolve_parameter_conflict(
+    name: str,
+    existing: Parameter,
+    incoming: Parameter,
+    conflicts: list[ConflictDetail],
+    policy: str,
+    resolver: str | ConflictResolver | None,
+) -> tuple[Parameter | None, str]:
+    """Resolve a parameter conflict according to *resolver* and *policy*."""
+
+    if callable(resolver):
+        resolved = resolver(name, existing, incoming, tuple(conflicts))
+        if not isinstance(resolved, Parameter):
+            raise TypeError("on_conflict callable must return an inspect.Parameter instance")
+        return resolved, "custom"
+
+    if resolver in (None, "raise"):
+        return None, "unresolved"
+
+    if resolver == "prefer-annotated":
+        return _select_parameter_candidate(
+            existing,
+            incoming,
+            policy,
+            lambda parameter: parameter.annotation is not Parameter.empty,
+        )
+
+    if resolver == "prefer-defaulted":
+        return _select_parameter_candidate(
+            existing,
+            incoming,
+            policy,
+            lambda parameter: parameter.default is not Parameter.empty,
+        )
+
+    raise ValueError(f"Unknown on_conflict strategy: {resolver}")
+
+
+def _select_parameter_candidate(
+    existing: Parameter,
+    incoming: Parameter,
+    policy: str,
+    predicate: Callable[[Parameter], bool],
+) -> tuple[Parameter, str]:
+    """Select a parameter based on *predicate* and *policy*."""
+
+    candidates: list[tuple[str, Parameter]] = []
+    if predicate(existing):
+        candidates.append(("existing", existing))
+    if predicate(incoming):
+        candidates.append(("incoming", incoming))
+
+    if not candidates:
+        candidates = [("existing", existing), ("incoming", incoming)]
+
+    if policy == "prefer-last":
+        source, parameter = candidates[-1]
+    else:
+        source, parameter = candidates[0]
+
+    return parameter, source
+
+
+def _finalise_resolved_parameter(
+    resolved: Parameter,
+    counterpart: Parameter,
+    conflicts: list[ConflictDetail],
+) -> Parameter:
+    """Fill in missing metadata on *resolved* using *counterpart* when safe."""
+
+    conflict_types = {kind for kind, _, _ in conflicts}
+    updated = resolved
+
+    if (
+        "default" not in conflict_types
+        and updated.default is Parameter.empty
+        and counterpart.default is not Parameter.empty
+    ):
+        updated = updated.replace(default=counterpart.default)
+
+    if (
+        "annotation" not in conflict_types
+        and updated.annotation is Parameter.empty
+        and counterpart.annotation is not Parameter.empty
+    ):
+        updated = updated.replace(annotation=counterpart.annotation)
+
+    return updated
+
+
+def _raise_parameter_conflict(name: str, conflicts: list[ConflictDetail]) -> None:
+    """Raise :class:`SignatureConflictError` with detailed conflict information."""
+
+    parts: list[str] = []
+    for conflict_type, existing_value, incoming_value in conflicts:
+        if conflict_type == "kind":
+            left = getattr(existing_value, "name", existing_value)
+            right = getattr(incoming_value, "name", incoming_value)
+            parts.append(f"kind {left} vs {right}")
+        elif conflict_type == "default":
+            parts.append(f"default {existing_value!r} vs {incoming_value!r}")
+        elif conflict_type == "annotation":
+            parts.append(f"annotation {existing_value!r} vs {incoming_value!r}")
+        else:
+            parts.append(conflict_type)
+
+    detail = ", ".join(parts)
+    raise SignatureConflictError(f"Parameter '{name}' conflict: {detail}")


### PR DESCRIPTION
## Summary
- add helper utilities to bucket parameters by kind and detect conflicts
- extend merge_signatures with policy, on_conflict strategies, and improved docstring
- choose return annotations from the right-most callable

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68dc608bbea883289eac47eabd99f567