### PR TITLE
Add comprehensive tests for signature utilities

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+"""Pytest configuration and shared fixtures."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+
+def _ensure_src_on_path() -> None:
+    root = pathlib.Path(__file__).resolve().parent.parent
+    src = root / "src"
+    src_path = str(src)
+    if src.exists() and src_path not in sys.path:
+        sys.path.insert(0, src_path)
+
+
+_ensure_src_on_path()
+
+
+__all__ = []

--- a/tests/test_combine.py
+++ b/tests/test_combine.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+"""Tests for :func:`signia.combine`."""
+
+import inspect
+
+import pytest
+
+from signia import combine, merge_signatures
+
+
+def primary(
+    x: int,
+    /,
+    y: str,
+    *numbers: float,
+    flag: bool = False,
+    **options: str,
+) -> tuple[int, str]:
+    return x, y
+
+
+def secondary(*, flag: bool, audit: list[str]) -> None:
+    audit.append(f"flag={flag}")
+
+
+def tertiary(*, trace: dict[str, str]) -> None:
+    trace.update({"used": "yes"})
+
+
+def test_combine_signature_and_routing():
+    wrapped = combine(primary, secondary, tertiary)
+    signature = inspect.signature(wrapped)
+    expected = merge_signatures(primary, secondary, tertiary)
+
+    assert signature == expected
+
+    audit: list[str] = []
+    trail: dict[str, str] = {}
+    result = wrapped(1, "two", 3.0, flag=True, audit=audit, trace=trail)
+
+    assert result == (1, "two")
+    assert audit == ["flag=True"]
+    assert trail == {"used": "yes"}
+
+
+def test_combine_unexpected_keyword_raises():
+    wrapped = combine(primary, secondary)
+
+    with pytest.raises(TypeError):
+        wrapped(1, "two", unknown=True)
+
+
+def test_combine_var_keyword_consumption():
+    def with_kwargs(x: int, /, **kwargs: int) -> int:
+        return x
+
+    def grab(**kwargs: int) -> None:
+        assert "extra" in kwargs
+
+    wrapped = combine(with_kwargs, grab)
+    wrapped(10, extra=5)
+
+
+def test_combine_method_behavior():
+    class Tool:
+        history: list[str]
+
+        def __init__(self) -> None:
+            self.history = []
+
+        def action(self, value: int, /, *, flag: bool = False) -> int:
+            self.history.append(f"action:{value}:{flag}")
+            return value
+
+        def log(self, /, *, note: str) -> None:
+            self.history.append(f"log:{note}")
+
+        invoke = combine(action, log)
+
+    tool = Tool()
+
+    result = tool.invoke(5, flag=True, note="done")
+
+    assert result == 5
+    assert tool.history == ["action:5:True", "log:done"]

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,0 +1,130 @@
+"""Tests for :func:`signia.merge_signatures`."""
+
+from __future__ import annotations
+
+import inspect
+from inspect import Parameter
+
+import pytest
+
+from signia import SignatureConflictError, merge_signatures
+
+
+def left(
+    a: int,
+    /,
+    b: str,
+    *args: float,
+    c: int = 1,
+    **kwargs: bool,
+) -> str:
+    return b
+
+
+def right(
+    a: int,
+    /,
+    *,
+    c: int = 1,
+    d: float,
+    **kwargs: bool,
+) -> str:
+    return str(d)
+
+
+def test_merge_signatures_groups_by_kind():
+    signature = merge_signatures(left, right)
+
+    parameters = list(signature.parameters.values())
+    expected_order = [
+        ("a", Parameter.POSITIONAL_ONLY),
+        ("b", Parameter.POSITIONAL_OR_KEYWORD),
+        ("args", Parameter.VAR_POSITIONAL),
+        ("c", Parameter.KEYWORD_ONLY),
+        ("d", Parameter.KEYWORD_ONLY),
+        ("kwargs", Parameter.VAR_KEYWORD),
+    ]
+
+    assert [(parameter.name, parameter.kind) for parameter in parameters] == expected_order
+    assert signature.parameters["c"].default == 1
+    assert signature.return_annotation == "str"
+
+
+def test_merge_signatures_conflicting_defaults_raise():
+    def right_conflicting(
+        a: int,
+        /,
+        *,
+        c: int = 2,
+        d: float,
+        **kwargs: bool,
+    ) -> str:
+        return str(d)
+
+    with pytest.raises(SignatureConflictError) as excinfo:
+        merge_signatures(left, right_conflicting, compare_defaults=True)
+
+    assert "default 1 vs 2" in str(excinfo.value)
+
+
+def test_merge_signatures_custom_resolver():
+    def resolver(name, existing, incoming, conflicts):
+        assert name == "c"
+        assert {kind for kind, *_ in conflicts} == {"default"}
+        assert existing.default == 1
+        assert incoming.default == 2
+        return existing.replace(default=42)
+
+    def right_conflicting(
+        a: int,
+        /,
+        *,
+        c: int = 2,
+        d: float,
+        **kwargs: bool,
+    ) -> str:
+        return str(d)
+
+    signature = merge_signatures(left, right_conflicting, on_conflict=resolver)
+    parameter = signature.parameters["c"]
+
+    assert parameter.default == 42
+    assert parameter.kind is Parameter.KEYWORD_ONLY
+
+
+def test_merge_signatures_policy_prefer_last():
+    def right_conflicting(
+        a: int,
+        /,
+        *,
+        c: int = 2,
+        d: float,
+        **kwargs: bool,
+    ) -> str:
+        return str(d)
+
+    signature = merge_signatures(
+        left,
+        right_conflicting,
+        policy="prefer-last",
+        compare_defaults=False,
+    )
+
+    assert signature.parameters["c"].default == 2
+
+
+def test_merge_signatures_prefer_annotated():
+    def annotated(a, *, b: int):
+        return a
+
+    def unannotated(a, *, b):
+        return a
+
+    signature = merge_signatures(unannotated, annotated, on_conflict="prefer-annotated")
+
+    assert signature.parameters["b"].annotation == "int"
+
+
+def test_merge_signatures_requires_input():
+    with pytest.raises(ValueError):
+        merge_signatures()

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -1,0 +1,50 @@
+"""Tests for :func:`signia.mirror_signature`."""
+
+from __future__ import annotations
+
+import inspect
+
+from signia import mirror_signature
+
+
+def sample_function(
+    x: int,
+    /,
+    y: str,
+    *values: float,
+    flag: bool = False,
+    **options: str,
+) -> str:
+    """Example function whose signature we mirror."""
+
+    parts = [y, *(str(value) for value in values)]
+    if flag:
+        parts.append("!")
+    parts.extend(sorted(options))
+    return " ".join(parts)
+
+
+def passthrough(*args, **kwargs):
+    """Target callable used for mirroring."""
+
+    return args, kwargs
+
+
+def test_mirror_signature_metadata():
+    decorated = mirror_signature(sample_function)(passthrough)
+
+    assert decorated.__doc__ == sample_function.__doc__
+    assert decorated.__name__ == sample_function.__name__
+    assert decorated.__wrapped__ is sample_function
+    assert inspect.signature(decorated) == inspect.signature(sample_function)
+
+
+def test_mirrored_callable_invocation():
+    decorated = mirror_signature(sample_function)(passthrough)
+
+    result = decorated(1, "two", 3.0, 4.0, flag=True, mode="test")
+
+    assert result == (
+        (1, "two", 3.0, 4.0),
+        {"flag": True, "mode": "test"},
+    )

--- a/tests/test_same.py
+++ b/tests/test_same.py
@@ -1,0 +1,105 @@
+"""Tests for :func:`signia.same_signature`."""
+
+from __future__ import annotations
+
+import inspect
+
+from signia import same_signature
+
+
+def _reference(
+    a: int,
+    /,
+    b: str,
+    *,
+    c: float = 1.0,
+    d: int | None = None,
+    **extras: bool,
+) -> str:
+    return f"{a}-{b}-{c}-{d}-{sorted(extras)}"
+
+
+def _identical(
+    a: int,
+    /,
+    b: str,
+    *,
+    c: float = 1.0,
+    d: int | None = None,
+    **extras: bool,
+) -> str:
+    return _reference(a, b, c=c, d=d, **extras)
+
+
+def _different_defaults(
+    a: int,
+    /,
+    b: str,
+    *,
+    c: float = 2.0,
+    d: int | None = None,
+    **extras: bool,
+) -> str:
+    return _reference(a, b, c=c, d=d, **extras)
+
+
+def _different_annotations(
+    a,
+    /,
+    b,
+    *,
+    c=1.0,
+    d=None,
+    **extras,
+):
+    return _reference(a, b, c=c, d=d, **extras)
+
+
+def _different_return(
+    a: int,
+    /,
+    b: str,
+    *,
+    c: float = 1.0,
+    d: int | None = None,
+    **extras: bool,
+) -> int:
+    return a
+
+
+def test_same_signature_strict_true():
+    assert same_signature(_reference, _identical)
+
+
+def test_same_signature_default_difference_requires_relaxed():
+    assert not same_signature(_reference, _different_defaults)
+    assert same_signature(_reference, _different_defaults, strict=False)
+
+
+def test_same_signature_annotation_controls():
+    assert not same_signature(_reference, _different_annotations)
+    assert same_signature(
+        _reference,
+        _different_annotations,
+        ignore_annotations=True,
+    )
+
+
+def test_same_signature_return_annotation_controls():
+    assert not same_signature(_reference, _different_return)
+    assert same_signature(_reference, _different_return, ignore_return=True)
+
+
+def test_same_signature_signature_objects():
+    signature = inspect.signature(_reference)
+    altered = signature.replace(return_annotation=int)
+
+    assert not same_signature(signature, altered)
+    assert same_signature(signature, altered, ignore_return=True)
+
+
+def test_same_signature_incompatible_structure():
+    def variant(a: int, b: str, *, c: float = 1.0) -> str:
+        return b
+
+    assert not same_signature(_reference, variant, strict=False)


### PR DESCRIPTION
## Summary
- add tests for mirror_signature, same_signature, merge_signatures, and combine covering metadata mirroring, comparison modes, and routing behaviour
- introduce pytest configuration ensuring the package source is importable during test collection

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dc64f5ad348328b3a701041be22b03