### PR TITLE
Add CallVars snapshots to combine wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ calls: list[str] = []
 wrapped = combine(load, audit)
 assert wrapped("demo.txt", logger=calls) == "DEMO.TXT"
 assert calls == ["load called"]
+
+# Inspect what each callable received
+assert load.vars.args == ("demo.txt",)
+assert audit.vars.kwargs == {"logger": calls}
 ```
 
 ``combine`` uses ``merge_signatures`` under the hood so that a single callable can

--- a/src/signia/__init__.py
+++ b/src/signia/__init__.py
@@ -1,6 +1,7 @@
 """Public Signia API."""
 
 from ._core import (
+    CallVars,
     SignatureConflictError,
     combine,
     merge_signatures,
@@ -9,6 +10,7 @@ from ._core import (
 )
 
 __all__ = [
+    "CallVars",
     "SignatureConflictError",
     "combine",
     "merge_signatures",


### PR DESCRIPTION
## Summary
- capture the bound arguments routed to each callable wrapped by `combine`
- expose the new `CallVars` helper and document how to introspect `.vars`
- cover the behaviour with unit tests for the stored argument snapshots

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc681579508328a076e013892efb02