### PR TITLE
Add mirror_signature tests for methods

### DIFF
--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -48,3 +48,38 @@ def test_mirrored_callable_invocation():
         (1, "two", 3.0, 4.0),
         {"flag": True, "mode": "test"},
     )
+
+
+def test_mirror_signature_on_method():
+    class Example:
+        @mirror_signature(sample_function)
+        def method(self, *args, **kwargs):
+            return self, args, kwargs
+
+    instance = Example()
+
+    assert inspect.signature(Example.method) == inspect.signature(sample_function)
+
+    received_self, args, kwargs = instance.method(1, "two", 3.0, flag=True)
+
+    assert received_self is instance
+    assert args == (1, "two", 3.0)
+    assert kwargs == {"flag": True}
+
+
+def test_mirror_signature_from_bound_method():
+    class Source:
+        def method(self, x: int, y: str, *, flag: bool = False) -> tuple[int, str, bool]:
+            return x, y, flag
+
+    bound_method = Source().method
+    decorated = mirror_signature(bound_method)(passthrough)
+
+    decorated_signature = inspect.signature(decorated)
+
+    assert "self" not in decorated_signature.parameters
+    assert decorated_signature == inspect.signature(bound_method)
+
+    result = decorated(5, "value", flag=True)
+
+    assert result == ((5, "value"), {"flag": True})


### PR DESCRIPTION
## Summary
- add coverage ensuring mirror_signature works when applied to instance methods
- test mirroring a bound method onto a standalone callable

## Testing
- pytest tests/test_mirror.py

------
https://chatgpt.com/codex/tasks/task_e_68dc6dc92d2083289a218d6642f1ba18