### PR TITLE
Add CallVars.unpack convenience helper

### DIFF
--- a/src/signia/_core.py
+++ b/src/signia/_core.py
@@ -50,6 +50,18 @@ class CallVars:
 
         return iter(self.arguments.items())
 
+    def unpack(self) -> OrderedDict[str, Any]:
+        """Return a shallow copy of the bound argument mapping.
+
+        The :attr:`arguments` attribute already exposes an ordered mapping of
+        parameter names to their supplied values.  ``unpack()`` mirrors that
+        data but as an explicit convenience API, allowing call sites to write
+        ``func.vars.unpack()`` when they want a mapping such as
+        ``{"a": 1, "b": 2, "c": 3}``.
+        """
+
+        return self.arguments.copy()
+
 
 def mirror_signature(src: Callable[..., Any]) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """Mirror a callable's signature and metadata onto another.

--- a/tests/test_combine.py
+++ b/tests/test_combine.py
@@ -107,11 +107,13 @@ def test_combine_exposes_call_vars():
     assert primary.vars.args == (1, 2)
     assert primary.vars.kwargs == {"flag": True}
     assert list(primary.vars.arguments.items()) == [("x", 1), ("y", 2), ("flag", True)]
+    assert list(primary.vars.unpack().items()) == [("x", 1), ("y", 2), ("flag", True)]
     assert primary.vars.result == 3
 
     assert audit.vars.args == ()
     assert audit.vars.kwargs == {"flag": True, "tracker": tracker}
     assert list(audit.vars.arguments.items()) == [("flag", True), ("tracker", tracker)]
+    assert list(audit.vars.unpack().items()) == [("flag", True), ("tracker", tracker)]
     assert audit.vars.result is None
 
     # Call again to ensure the snapshots refresh rather than accumulate.
@@ -122,6 +124,9 @@ def test_combine_exposes_call_vars():
     assert primary.vars.args == (5, 10)
     assert primary.vars.kwargs == {"flag": False}
     assert list(primary.vars.arguments.items())[-1] == ("flag", False)
+    unpacked = primary.vars.unpack()
+    unpacked["flag"] = True
+    assert primary.vars.arguments["flag"] is False
     assert primary.vars.result == 15
 
 


### PR DESCRIPTION
## Summary
- add a CallVars.unpack() helper that returns the ordered mapping of bound arguments
- cover the helper with regression tests to verify ordering and copy semantics

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc6e01fd9c8328b1bbf71296762f9e