### PR TITLE
Add SigniaWarning to public API

### DIFF
--- a/src/signia/__init__.py
+++ b/src/signia/__init__.py
@@ -2,6 +2,7 @@
 
 from ._core import (
     CallVars,
+    SigniaWarning,
     SignatureConflictError,
     combine,
     merge_signatures,
@@ -11,6 +12,7 @@ from ._core import (
 
 __all__ = [
     "CallVars",
+    "SigniaWarning",
     "SignatureConflictError",
     "combine",
     "merge_signatures",

--- a/src/signia/_core.py
+++ b/src/signia/_core.py
@@ -11,6 +11,7 @@ from typing import Any, Callable
 
 __all__ = [
     "CallVars",
+    "SigniaWarning",
     "SignatureConflictError",
     "combine",
     "merge_signatures",
@@ -34,6 +35,10 @@ ConflictResolver = Callable[[str, Parameter, Parameter, tuple[ConflictDetail, ..
 
 class SignatureConflictError(ValueError):
     """Raised when merging callables hits conflicting signature metadata."""
+
+
+class SigniaWarning(Warning):
+    """Base warning class for the Signia package."""
 
 
 @dataclass(frozen=True)

--- a/tests/test_fuse.py
+++ b/tests/test_fuse.py
@@ -1,0 +1,9 @@
+"""Public surface guardrails for Signia."""
+
+from signia import SigniaWarning
+
+
+def test_signia_warning_is_warning():
+    """Ensure the exported warning derives from :class:`Warning`."""
+
+    assert issubclass(SigniaWarning, Warning)


### PR DESCRIPTION
## Summary
- add a dedicated `SigniaWarning` base class to the core module and export it publicly
- cover the new warning with a sanity test to ensure it remains a subclass of `Warning`

## Testing
- pytest tests/test_fuse.py

------
https://chatgpt.com/codex/tasks/task_e_68dd9ec76bf4832886358d5d43abf9b8