### PR TITLE
Add fused source proxy helper for fused call reuse

### DIFF
--- a/src/signia/__init__.py
+++ b/src/signia/__init__.py
@@ -2,6 +2,7 @@
 
 from ._core import (
     CallVars,
+    SigniaWarning,
     SignatureConflictError,
     combine,
     merge_signatures,
@@ -11,6 +12,7 @@ from ._core import (
 
 __all__ = [
     "CallVars",
+    "SigniaWarning",
     "SignatureConflictError",
     "combine",
     "merge_signatures",

--- a/tests/test_fuse.py
+++ b/tests/test_fuse.py
@@ -1,0 +1,50 @@
+"""Tests for the fused source proxy helpers."""
+
+from __future__ import annotations
+
+import inspect
+
+from signia._core import _FusedSourceProxy
+
+
+def test_proxy_memoizes_zero_arg_calls():
+    calls: list[tuple[int, int]] = []
+
+    def target(x: int, *, y: int) -> int:
+        calls.append((x, y))
+        return x + y
+
+    proxy = _FusedSourceProxy(target, 2, y=3)
+
+    assert proxy() == 5
+    assert proxy() == 5
+    assert calls == [(2, 3)]
+
+
+def test_proxy_overrides_bypass_cache():
+    calls: list[tuple[int, int]] = []
+
+    def target(x: int, *, y: int) -> int:
+        calls.append((x, y))
+        return x + y
+
+    proxy = _FusedSourceProxy(target, 4, y=5)
+
+    assert proxy() == 9
+    assert proxy(y=7) == 11
+    assert calls == [(4, 5), (4, 7)]
+    assert proxy() == 9
+    assert calls == [(4, 5), (4, 7)]
+
+
+def test_proxy_defaults_and_signature_snapshot():
+    def sample(a: int, b: int = 2, *, c: int = 3, d: int) -> int:
+        return a + b + c + d
+
+    proxy = _FusedSourceProxy(sample, 1, d=4)
+
+    assert proxy.args == (1,)
+    assert dict(proxy.kw) == {"d": 4}
+    assert proxy.signature == inspect.signature(sample)
+    assert list(proxy.params) == ["a", "b", "c", "d"]
+    assert proxy.defaults == {"b": 2, "c": 3}


### PR DESCRIPTION
## Summary
- add a `_FusedSourceProxy` helper that preserves signature metadata, memoizes zero-arg reuse, and warns on missing required overrides
- expose the new `SigniaWarning` type through the package namespace
- cover the proxy helper with tests for memoization, override behaviour, and default snapshots

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68dd9ed9227c8328a54f02768750c528