### PR TITLE
Deduplicate SigniaWarning definition

### DIFF
--- a/src/signia/_core.py
+++ b/src/signia/_core.py
@@ -15,16 +15,11 @@ __all__ = [
     "CallVars",
     "SigniaWarning",
     "SignatureConflictError",
-    "SigniaWarning",
     "combine",
     "merge_signatures",
     "mirror_signature",
     "same_signature",
 ]
-
-
-class SigniaWarning(UserWarning):
-    """Base warning for Signia-specific warnings."""
 
 
 _CACHE_MISS = object()
@@ -144,8 +139,8 @@ class SignatureConflictError(ValueError):
     """Raised when merging callables hits conflicting signature metadata."""
 
 
-class SigniaWarning(Warning):
-    """Base warning class for the Signia package."""
+class SigniaWarning(UserWarning):
+    """Base warning for Signia-specific warnings."""
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary
- remove the duplicate SigniaWarning definition in _core.py
- ensure SigniaWarning inherits from UserWarning while keeping exports clean

## Testing
- pytest tests/test_fuse.py

------
https://chatgpt.com/codex/tasks/task_e_68dda6d03b348328b4dde5b350530b07